### PR TITLE
logic to handle 1st time call - ProvisionDatabase

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
- ThisBuild / version := "0.0.1"
+ ThisBuild / version := "0.0.2"


### PR DESCRIPTION

In case 1st time provision database, to avoid the following error

```
[info] alter table "dataset_lineage" drop constraint "pk_dataset_lineage"
[info] drop table if exists "dataset_lineage"
[error] Exception in thread "main" org.postgresql.util.PSQLException: ERROR: relation "dataset_lineage" does not exist
```

repeated (non 1st time) call to provision database does not get the error.  
