### PR TITLE
conf file clean up (mis-matched parenthesis)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ how to deploy the service.
 To setup the database run `com.salesforce.mce.acdc.tool.ProvisionDatabase`.
 
 ```shell 
+export POSTGRES_PASSWORD=<my db password>
 sbt 'project core; run ProvisionDatabase'
 ```
 

--- a/acdc-ws/conf/application.conf
+++ b/acdc-ws/conf/application.conf
@@ -15,13 +15,13 @@
 # HOCON will fall back to substituting environment variable:
 #mykey = ${JAVA_HOME}
 
-acdc-api-key = "f6e42a3c0dffee079face0da061ee2c9a871eebe098ac481248e34cfe023955b"
 acdc.auth = {
     enabled = false
     header-name = "x-api-key"
     hashed-keys = {
         user = [ ${?MCE_ENV_X_API_USER1} , ${?MCE_ENV_X_API_USER2} ]
         admin = [ ${?MCE_ENV_X_API_ADMIN1} , ${?MCE_ENV_X_API_ADMIN2} ]
+    }
 }
 
 ## Akka

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
- ThisBuild / version := "0.0.4"
+ ThisBuild / version := "0.0.5"


### PR DESCRIPTION

After local machine restart and without ENV set properly, got this error.  The root cause is config parsing error.

```
[error] a.a.ActorSystemImpl - Internal server error, sending 500 response
akka.http.impl.util.One2OneBidiFlow$OutputTruncationException: Inner flow was completed without producing result elements for 1 outstanding elements
```

I added to the README ```export POSTGRES_PASSWORD=abc``` to address it.  

Plus to fix a missing ```}``` in application.conf
