### PR TITLE
Rename metric endpoint

### DIFF
--- a/acdc-ws/conf/application.conf
+++ b/acdc-ws/conf/application.conf
@@ -364,8 +364,8 @@ play.assets {
 acdc.metrics {
   # User configurable metric endpoint at /api/v1/[endpoint].
   # If endpoint is undefined, metrics will not be collected
-  endpoint = "metrics"
+  endpoint = "__metrics"
 
   # Disable metric collection for these request paths
-  bypass.paths = ["/__status", "/", "/api/v1/metrics"]
+  bypass.paths = ["/__status", "/", "/api/v1/__metrics"]
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
- ThisBuild / version := "0.8.0"
+ ThisBuild / version := "0.8.1"


### PR DESCRIPTION
Current load balancer filters out routes following a regex rule.  To circumvent this, the metric endpoint needs to be pre-pended with "__".

risk: low