### PR TITLE
Refactor metric endpoint to static route

### DIFF
--- a/acdc-ws/app/routers/ApiRouter.scala
+++ b/acdc-ws/app/routers/ApiRouter.scala
@@ -9,22 +9,16 @@ package routers
 
 import javax.inject.Inject
 
-import play.api.Configuration
 import play.api.routing.sird._
 import play.api.routing.{Router, SimpleRouter}
 
-import com.typesafe.config.ConfigFactory
 import controllers._
 
 class ApiRouter @Inject() (
   dataset: DatasetController,
   instance: DatasetInstanceController,
-  lineage: DatasetLineageController,
-  metrics: MetricController,
-  status: StatusController
+  lineage: DatasetLineageController
 ) extends SimpleRouter {
-
-  private lazy val config = new Configuration(ConfigFactory.load())
 
   override def routes: Router.Routes = {
     case POST(p"/dataset") => dataset.create()
@@ -60,12 +54,6 @@ class ApiRouter @Inject() (
     case PUT(p"/lineage/$destName") => lineage.setSources(destName)
     case GET(p"/lineage/$destName") => lineage.getSources(destName)
     case DELETE(p"/lineage/$destName") => lineage.delete(destName)
-
-    case GET(p"/$other") =>
-      config.getOptional[String]("acdc.metrics.endpoint") match {
-        case Some(endpoint) if other.equals(endpoint) => metrics.collect
-        case _ => status.notFound
-      }
 
   }
 

--- a/acdc-ws/app/services/Metric.scala
+++ b/acdc-ws/app/services/Metric.scala
@@ -15,8 +15,8 @@ import io.prometheus.client.hotspot.DefaultExports
 trait Metric {
   private lazy val config = new Configuration(ConfigFactory.load())
 
-  private val disableMetrics =
-    config.getOptional[String]("acdc.metrics.endpoint").getOrElse("").isEmpty
+  private val enableMetrics =
+    config.getOptional[Boolean]("acdc.metrics.enable").getOrElse(false)
 
   private val bypassPaths = config.getOptional[Seq[String]]("acdc.metrics.bypass.paths") match {
     case Some(paths) => paths.toSet
@@ -26,7 +26,7 @@ trait Metric {
   private val staticPathMarkers = Seq("instance", "dataset", "lineage", "__metrics", "__status")
 
   def parseRequest(request: RequestHeader): Option[(String, String)] = {
-    if (checkPathIsDisabled(request.path) || checkMetricIsDisabled)
+    if (checkPathIsDisabled(request.path) || !checkMetricIsEnabled)
       None
     else {
       val (staticPath, args) = request.path
@@ -42,7 +42,7 @@ trait Metric {
     }
   }
 
-  def checkMetricIsDisabled: Boolean = { disableMetrics }
+  def checkMetricIsEnabled: Boolean = { enableMetrics }
 
   def checkPathIsDisabled(path: String): Boolean = { bypassPaths.contains(path) }
 

--- a/acdc-ws/conf/application.conf
+++ b/acdc-ws/conf/application.conf
@@ -362,10 +362,8 @@ play.assets {
 
 # some http request paths are not interesting to capture metrics such as http duration
 acdc.metrics {
-  # User configurable metric endpoint at /api/v1/[endpoint].
-  # If endpoint is undefined, metrics will not be collected
-  endpoint = "__metrics"
+  enable = true
 
   # Disable metric collection for these request paths
-  bypass.paths = ["/__status", "/", "/api/v1/__metrics"]
+  bypass.paths = ["/__status", "/", "/__metrics"]
 }

--- a/acdc-ws/conf/routes
+++ b/acdc-ws/conf/routes
@@ -1,3 +1,4 @@
 GET     /__status                   controllers.StatusController.status()
+GET     /__metrics                  controllers.MetricController.collect()
 
 ->      /api/v1                     routers.ApiRouter

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
- ThisBuild / version := "0.8.1"
+ ThisBuild / version := "0.8.2"


### PR DESCRIPTION
Pull request refactor metric endpoint from dynamic path to static path without path /api/v1 offset.