### PR TITLE
update jackson-databind dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,6 +53,7 @@ lazy val ws = (project in file("acdc-ws")).
       prometheusHotSpot
     ),
     dependencyOverrides ++= Seq(
+      // fix https://nvd.nist.gov/vuln/detail/CVE-2020-36518
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.4"
     )
   ).

--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,9 @@ lazy val ws = (project in file("acdc-ws")).
       prometheusClient,
       prometheusCommon,
       prometheusHotSpot
+    ),
+    dependencyOverrides ++= Seq(
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.4"
     )
   ).
   dependsOn(core)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
- ThisBuild / version := "0.8.3"
+ ThisBuild / version := "0.8.4"


### PR DESCRIPTION
Fixes https://nvd.nist.gov/vuln/detail/CVE-2020-36518