### PR TITLE
simplify prometheus label for http request's path to keep only a prefix

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
- ThisBuild / version := "0.8.8"
+ ThisBuild / version := "0.8.9"


### PR DESCRIPTION

reduce the cardinality of the apiLatency prometheus summary metric label