### PR TITLE
update apiLatencySummary label keys (take out argument)

### DIFF
--- a/acdc-ws/app/services/Metric.scala
+++ b/acdc-ws/app/services/Metric.scala
@@ -70,7 +70,7 @@ class PrometheusMetric @Inject() (implicit ec: ExecutionContext) extends Metric 
   private val apiLatency: Summary = Summary
     .build()
     .name("apiLatencySummary")
-    .labelNames("path", "arguments", "method")
+    .labelNames("path", "method")
     .help("Profile API response time summary")
     .quantile(0.5d, 0.001d)
     .quantile(0.95d, 0.001d)

--- a/acdc-ws/app/utils/MetricFilter.scala
+++ b/acdc-ws/app/utils/MetricFilter.scala
@@ -27,7 +27,6 @@ class MetricFilter @Inject() (
           case patt(prefix) => prefix
           case _ => ""
         }
-        // hardcode argument to "" so as to control the number of time series
         val stopTimerCallback = metric.startApiTimer(simplePath, requestHeader.method)
 
         nextFilter(requestHeader)

--- a/acdc-ws/app/utils/MetricFilter.scala
+++ b/acdc-ws/app/utils/MetricFilter.scala
@@ -21,14 +21,14 @@ class MetricFilter @Inject() (
     nextFilter: RequestHeader => Future[Result]
   )(requestHeader: RequestHeader): Future[Result] = {
     metric.parseRequest(requestHeader) match {
-      case Some((staticPath, argument)) =>
+      case Some((staticPath, _)) =>
         // simplify path to control prometheus summary metric label cardinality
         val simplePath = staticPath match {
           case patt(prefix) => prefix
           case _ => ""
         }
         // hardcode argument to "" so as to control the number of time series
-        val stopTimerCallback = metric.startApiTimer(simplePath, "", requestHeader.method)
+        val stopTimerCallback = metric.startApiTimer(simplePath, requestHeader.method)
 
         nextFilter(requestHeader)
           .transform(

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
- ThisBuild / version := "0.8.9"
+ ThisBuild / version := "0.8.10"


### PR DESCRIPTION

the prometheus metric label (argument) is too detailed in the metrics tracking given the way acdc is called, it is not used currently anyway.  Take it out to keep the JVM memory used lower for the summary metric calculation. 