### PR TITLE
Acdc count metrics on DB table records

### DIFF
--- a/acdc-core/src/main/scala/com/salesforce/mce/acdc/db/DatasetInstanceQuery.scala
+++ b/acdc-core/src/main/scala/com/salesforce/mce/acdc/db/DatasetInstanceQuery.scala
@@ -35,6 +35,8 @@ object DatasetInstanceQuery {
 
   def forDataset(dataset: String) = DatasetInstanceTable().filter(_.dataset === dataset).result
 
+  def count() = DatasetInstanceTable().length.result
+
   def filter(
     dataset: Option[String],
     like: Option[String],
@@ -59,7 +61,8 @@ object DatasetInstanceQuery {
         (t, d) => t.filter(r => r.dataset === d)
       )
 
-    like.foldLeft(filteredByDataset)((t, l) => t.filter(r => r.name.like(l)))
+    like
+      .foldLeft(filteredByDataset)((t, l) => t.filter(r => r.name.like(l)))
       .sortBy(sortByColumn)
       .drop(offset)
       .take(limit)

--- a/acdc-core/src/main/scala/com/salesforce/mce/acdc/db/DatasetLineageQuery.scala
+++ b/acdc-core/src/main/scala/com/salesforce/mce/acdc/db/DatasetLineageQuery.scala
@@ -13,6 +13,8 @@ import slick.jdbc.PostgresProfile.api._
 
 object DatasetLineageQuery {
 
+  def count() = DatasetLineageTable().length.result
+
   case class ForDestination(dest: String) {
 
     def table = DatasetLineageTable().filter(_.toDataset === dest)

--- a/acdc-core/src/main/scala/com/salesforce/mce/acdc/db/DatasetQuery.scala
+++ b/acdc-core/src/main/scala/com/salesforce/mce/acdc/db/DatasetQuery.scala
@@ -29,6 +29,8 @@ object DatasetQuery {
 
   def now() = LocalDateTime.now()
 
+  def count() = DatasetTable().length.result
+
   case class ForName(name: String) {
 
     def table = DatasetTable().filter(_.name === name)

--- a/acdc-ws/app/Module.scala
+++ b/acdc-ws/app/Module.scala
@@ -8,7 +8,7 @@
 import com.google.inject.AbstractModule
 
 import services.{Metric, PrometheusMetric}
-import tasks.{AuthSettingReloadTask, DataInstExpirationTask}
+import tasks.{AuthSettingReloadTask, DataCountTask, DataInstExpirationTask}
 import utils.{Authorization, AuthorizationSettings}
 
 class Module extends AbstractModule {
@@ -22,6 +22,8 @@ class Module extends AbstractModule {
     bind(classOf[Metric]).to(classOf[PrometheusMetric])
     // Data forget task
     bind(classOf[DataInstExpirationTask]).asEagerSingleton()
+    // Data count task
+    bind(classOf[DataCountTask]).asEagerSingleton()
   }
 
 }

--- a/acdc-ws/app/services/Metric.scala
+++ b/acdc-ws/app/services/Metric.scala
@@ -54,6 +54,8 @@ trait Metric {
 
   def clear(): Unit
 
+  def countDB(table: String, cnt: Double): Unit
+
 }
 
 @Singleton
@@ -76,6 +78,17 @@ class PrometheusMetric @Inject() (implicit ec: ExecutionContext) extends Metric 
     .quantile(0.95d, 0.001d)
     .quantile(0.99d, 0.001d)
     .register
+
+  private val dbCountGauge = Gauge
+    .build()
+    .name("acdc_db_record_count")
+    .labelNames("table")
+    .help("acdc DB table records count")
+    .register
+
+  override def countDB(table: String, cnt: Double): Unit = {
+    dbCountGauge.labels(table).set(cnt)
+  }
 
   override def incrementStatusCount(status: String): Unit = {
     httpStatusCount.labels(status).inc()

--- a/acdc-ws/app/tasks/DataCountTask.scala
+++ b/acdc-ws/app/tasks/DataCountTask.scala
@@ -14,13 +14,14 @@ import com.salesforce.mce.acdc.db.{
   DatasetLineageQuery,
   DatasetQuery
 }
-import services.DatabaseService
+import services.{DatabaseService, Metric}
 import utils.DbConfig
 
 class DataCountTask @Inject() (
   actorSystem: ActorSystem,
   dbService: DatabaseService,
-  dbConfig: DbConfig
+  dbConfig: DbConfig,
+  metric: Metric
 )(implicit
   ec: ExecutionContext
 ) extends Logging {
@@ -38,7 +39,9 @@ class DataCountTask @Inject() (
       logger.debug(s"Counted $datasetInstanceCount records from dataset_instance ...")
       logger.debug(s"Counted $datasetLineageCount records from dataset_lineage ...")
 
-      // TODO: log via extending kineticpulse PrometheusMetric for metrics scraping
+      metric.countDB("dataset", datasetCount.toDouble)
+      metric.countDB("dataset-instance", datasetInstanceCount.toDouble)
+      metric.countDB("dataset-lineage", datasetLineageCount.toDouble)
 
       refresh()
     }

--- a/acdc-ws/app/tasks/DataCountTask.scala
+++ b/acdc-ws/app/tasks/DataCountTask.scala
@@ -1,0 +1,52 @@
+package tasks
+
+import javax.inject.Inject
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.DurationInt
+
+import akka.actor.ActorSystem
+import play.api.Logging
+
+import com.salesforce.mce.acdc.db.{
+  AcdcDatabase,
+  DatasetInstanceQuery,
+  DatasetLineageQuery,
+  DatasetQuery
+}
+import services.DatabaseService
+import utils.DbConfig
+
+class DataCountTask @Inject() (
+  actorSystem: ActorSystem,
+  dbService: DatabaseService,
+  dbConfig: DbConfig
+)(implicit
+  ec: ExecutionContext
+) extends Logging {
+
+  val countFrequency: Int = dbConfig.countTaskFrequencyMinute
+  def db: AcdcDatabase = dbService.db
+
+  def refresh(): Unit = {
+    actorSystem.scheduler.scheduleOnce(countFrequency.minutes) {
+      val datasetCount = db.sync(DatasetQuery.count())
+      val datasetInstanceCount = db.sync(DatasetInstanceQuery.count())
+      val datasetLineageCount = db.sync(DatasetLineageQuery.count())
+
+      logger.debug(s"Counted $datasetCount records from dataset ...")
+      logger.debug(s"Counted $datasetInstanceCount records from dataset_instance ...")
+      logger.debug(s"Counted $datasetLineageCount records from dataset_lineage ...")
+
+      // TODO: log via extending kineticpulse PrometheusMetric for metrics scraping
+
+      refresh()
+    }
+  }
+
+  if (countFrequency > 0) {
+    refresh()
+  } else {
+    logger.info("data count frequency is not a positive integer, data count task skipped.")
+  }
+}

--- a/acdc-ws/app/utils/DbConfig.scala
+++ b/acdc-ws/app/utils/DbConfig.scala
@@ -11,8 +11,9 @@ import scala.util.{Failure, Success, Try}
 
 import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigFactory
+import play.api.Logging
 
-class DbConfig() {
+class DbConfig() extends Logging {
 
   val config = ConfigFactory.load().getConfig("acdc.db")
 
@@ -20,6 +21,13 @@ class DbConfig() {
     case Success(d) => d
     case Failure(e: ConfigException.Missing) => 90
     case Failure(e) => throw e
+  }
+
+  def countTaskFrequencyMinute: Int = Try(config.getInt(s"count-task-frequency-minute")) match {
+    case Success(d) => d
+    case _ =>
+      logger.warn("No config found for count-task-frequency-minute, defaulting to 0.")
+      0
   }
 
 }

--- a/acdc-ws/app/utils/DbConfig.scala
+++ b/acdc-ws/app/utils/DbConfig.scala
@@ -25,9 +25,10 @@ class DbConfig() extends Logging {
 
   def countTaskFrequencyMinute: Int = Try(config.getInt(s"count-task-frequency-minute")) match {
     case Success(d) => d
-    case _ =>
+    case Failure(e: ConfigException.Missing) =>
       logger.warn("No config found for count-task-frequency-minute, defaulting to 0.")
       0
+    case Failure(e) => throw e
   }
 
 }

--- a/acdc-ws/conf/application.conf
+++ b/acdc-ws/conf/application.conf
@@ -32,6 +32,11 @@ acdc.auth = {
 acdc.db {
     # maximum length in days to keep
     ttl = ${?DATA_TTL}
+
+    # count and report records in dataset, datasetInstance, and datasetLineage tables
+    # 0 is to skip data count task, set it to a positive Int for effective count frequency
+    count-task-frequency-minute = 0
+    count-task-frequency-minute = ${?COUNT_TASK_FREQUENCY_MINUTE}
 }
 
 ## Akka

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
- ThisBuild / version := "0.8.11"
+ ThisBuild / version := "0.8.12"


### PR DESCRIPTION

DataCountTask to report metrics for main acdc DB objects

akka scheduler to count and report acdc DB objects

when kineticpulse is integrated, TODO: refactor metric gauge 

To local test, `docker compose up -d `
on container ws
```
/acdc/ws # export COUNT_TASK_FREQUENCY_MINUTE=1
/acdc/ws # sbt ws/run
```

Example metrics outcome
```
# HELP acdc_db_record_count acdc DB table records count
# TYPE acdc_db_record_count gauge
acdc_db_record_count{table="dataset-lineage",} 0.0
acdc_db_record_count{table="dataset",} 4.0
acdc_db_record_count{table="dataset-instance",} 3.0
```

Signed-off-by: simon.chow <simon.chow@salesforce.com>
