### PR TITLE
Add xfcc header auth

### DIFF
--- a/acdc-ws/app/utils/Authorization.scala
+++ b/acdc-ws/app/utils/Authorization.scala
@@ -24,21 +24,21 @@ class Authorization(private var authorizationSettings: AuthorizationSettings) {
     (authorizationSettings.apiKeyAuthEnabled, authorizationSettings.xfccKeyAuthEnabled) match {
       case (true, true) =>
         if (getKeyRoles(request.headers.get(authorizationSettings.apiKeyAuthHeader)) ==
-          getSpiffe(request.headers.get(authorizationSettings.xfccAuthHeader))) {
+          getXfccRoles(request.headers.get(authorizationSettings.xfccAuthHeader))) {
           List(Admin)
         } else {
           List.empty
         }
       case (true, false) => getKeyRoles(request.headers.get(authorizationSettings.apiKeyAuthHeader))
-      case (false, true) => getSpiffe(request.headers.get(authorizationSettings.xfccAuthHeader))
+      case (false, true) => getXfccRoles(request.headers.get(authorizationSettings.xfccAuthHeader))
       case (false, false) => List(Admin)
     }
   }
 
-  private def getSpiffe(key: Option[String]) = {
+  private def getXfccRoles(key: Option[String]) = {
     key match {
       case Some(xfcc) =>
-        if (authorizationSettings.xfccShouldContain.forall(xfcc.contains)) { List(Admin) }
+        if (xfcc.contains(authorizationSettings.xfccMustContain)) { List(Admin) }
         else { List.empty }
       case None => List.empty
     }

--- a/acdc-ws/app/utils/AuthorizationSettings.scala
+++ b/acdc-ws/app/utils/AuthorizationSettings.scala
@@ -17,13 +17,20 @@ import com.typesafe.config.{Config, ConfigFactory, ConfigList}
 
 class AuthorizationSettings private (config: Config) {
 
-  def authHeader: String = config.getString(s"header-name")
+  def apiKeyAuthHeader: String = config.getString(s"apikey.header-name")
 
-  def authEnabled: Boolean = config.getBoolean(s"enabled")
+  def apiKeyAuthEnabled: Boolean = config.getBoolean("apikey.enabled")
+
+  def xfccAuthHeader: String = config.getString("xfcc.header-name")
+
+  def xfccKeyAuthEnabled: Boolean = config.getBoolean("xfcc.enabled")
+
+  def xfccShouldContain: List[String] =
+    config.getStringList("xfcc.must-contain").toArray.toList.map(_.toString)
 
   def keyRoles: Map[String, List[String]] = {
     val userRoles = for {
-      (r, us) <- config.getConfig("hashed-keys").root().asScala.toList
+      (r, us) <- config.getConfig("apikey.hashed-keys").root().asScala.toList
       u <- us.asInstanceOf[ConfigList].unwrapped().asScala
     } yield u.toString() -> r
 

--- a/acdc-ws/app/utils/AuthorizationSettings.scala
+++ b/acdc-ws/app/utils/AuthorizationSettings.scala
@@ -17,9 +17,9 @@ import com.typesafe.config.{Config, ConfigFactory, ConfigList}
 
 class AuthorizationSettings private (config: Config) {
 
-  def apiKeyAuthHeader: String = config.getString(s"apikey.header-name")
+  def apiKeyAuthHeader: String = config.getString(s"header-name")
 
-  def apiKeyAuthEnabled: Boolean = config.getBoolean("apikey.enabled")
+  def apiKeyAuthEnabled: Boolean = config.getBoolean("enabled")
 
   def xfccAuthHeader: String = config.getString("xfcc.header-name")
 
@@ -29,7 +29,7 @@ class AuthorizationSettings private (config: Config) {
 
   def keyRoles: Map[String, List[String]] = {
     val userRoles = for {
-      (r, us) <- config.getConfig("apikey.hashed-keys").root().asScala.toList
+      (r, us) <- config.getConfig("hashed-keys").root().asScala.toList
       u <- us.asInstanceOf[ConfigList].unwrapped().asScala
     } yield u.toString() -> r
 

--- a/acdc-ws/app/utils/AuthorizationSettings.scala
+++ b/acdc-ws/app/utils/AuthorizationSettings.scala
@@ -25,8 +25,7 @@ class AuthorizationSettings private (config: Config) {
 
   def xfccKeyAuthEnabled: Boolean = config.getBoolean("xfcc.enabled")
 
-  def xfccShouldContain: List[String] =
-    config.getStringList("xfcc.must-contain").toArray.toList.map(_.toString)
+  def xfccMustContain: String = config.getString("xfcc.must-contain")
 
   def keyRoles: Map[String, List[String]] = {
     val userRoles = for {

--- a/acdc-ws/conf/application.conf
+++ b/acdc-ws/conf/application.conf
@@ -27,7 +27,6 @@ acdc.auth = {
         header-name = ${?XFCC_HEADER_NAME}
         must-contain = ${?XFCC_MUST_CONTAIN}
     }
-}
 
     # referesh settings every x seconds, setting it to null will make it never refresh. Note also
     # it only works if auth is specified as an external source config, setting it along with play's

--- a/acdc-ws/conf/application.conf
+++ b/acdc-ws/conf/application.conf
@@ -25,7 +25,7 @@ acdc.auth = {
         }
     }
     xfcc = {
-        enabled = true
+        enabled = false
         header-name = "X_FORWARDED_CLIENT_CERT"
         must-contain = "xfcc-must-contain-this-string"
     }

--- a/acdc-ws/conf/application.conf
+++ b/acdc-ws/conf/application.conf
@@ -16,19 +16,18 @@
 #mykey = ${JAVA_HOME}
 
 acdc.auth = {
-    apikey = {
-        enabled = false
-        header-name = "x-api-key"
-        hashed-keys = {
-            user = [ ${?MCE_ENV_X_API_USER1} , ${?MCE_ENV_X_API_USER2} ]
-            admin = [ ${?MCE_ENV_X_API_ADMIN1} , ${?MCE_ENV_X_API_ADMIN2} ]
-        }
+    enabled = false
+    header-name = "x-api-key"
+    hashed-keys = {
+        user = [ ${?MCE_ENV_X_API_USER1} , ${?MCE_ENV_X_API_USER2} ]
+        admin = [ ${?MCE_ENV_X_API_ADMIN1} , ${?MCE_ENV_X_API_ADMIN2} ]
     }
     xfcc = {
         enabled = false
-        header-name = "X_FORWARDED_CLIENT_CERT"
-        must-contain = "xfcc-must-contain-this-string"
+        header-name = ${?XFCC_HEADER_NAME}
+        must-contain = ${?XFCC_MUST_CONTAIN}
     }
+}
 
     # referesh settings every x seconds, setting it to null will make it never refresh. Note also
     # it only works if auth is specified as an external source config, setting it along with play's

--- a/acdc-ws/conf/application.conf
+++ b/acdc-ws/conf/application.conf
@@ -25,9 +25,9 @@ acdc.auth = {
         }
     }
     xfcc = {
-        enabled = false
+        enabled = true
         header-name = "X_FORWARDED_CLIENT_CERT"
-        must-contain = [ "string1", "string2" ]
+        must-contain = "xfcc-must-contain-this-string"
     }
 
     # referesh settings every x seconds, setting it to null will make it never refresh. Note also

--- a/acdc-ws/conf/application.conf
+++ b/acdc-ws/conf/application.conf
@@ -16,12 +16,20 @@
 #mykey = ${JAVA_HOME}
 
 acdc.auth = {
-    enabled = false
-    header-name = "x-api-key"
-    hashed-keys = {
-        user = [ ${?MCE_ENV_X_API_USER1} , ${?MCE_ENV_X_API_USER2} ]
-        admin = [ ${?MCE_ENV_X_API_ADMIN1} , ${?MCE_ENV_X_API_ADMIN2} ]
+    apikey = {
+        enabled = false
+        header-name = "x-api-key"
+        hashed-keys = {
+            user = [ ${?MCE_ENV_X_API_USER1} , ${?MCE_ENV_X_API_USER2} ]
+            admin = [ ${?MCE_ENV_X_API_ADMIN1} , ${?MCE_ENV_X_API_ADMIN2} ]
+        }
     }
+    xfcc = {
+        enabled = false
+        header-name = "X_FORWARDED_CLIENT_CERT"
+        must-contain = [ "string1", "string2" ]
+    }
+
     # referesh settings every x seconds, setting it to null will make it never refresh. Note also
     # it only works if auth is specified as an external source config, setting it along with play's
     # setting will prevent it from being reloaded, and the reload/cache is handled at playframework

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@ services:
     ports:
       - 9001:9000
     tty: true # for easy debugging
-    # command:
-    #   sbt ws/run
+    command:
+      sbt ws/run
   db:
     image: postgres
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@ services:
     ports:
       - 9001:9000
     tty: true # for easy debugging
-    command:
-      sbt ws/run
+    # command:
+    #   sbt ws/run
   db:
     image: postgres
     volumes:

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
- ThisBuild / version := "0.10.1"
+ ThisBuild / version := "0.11.0"


### PR DESCRIPTION
Adds xfcc header content check as an auth option that can be used with or without api key auth.